### PR TITLE
Constants ulong type was not properly detected

### DIFF
--- a/src/Generator/CsCodeGenerator.Enum.cs
+++ b/src/Generator/CsCodeGenerator.Enum.cs
@@ -361,10 +361,14 @@ namespace Generator
 
         private static string NormalizeEnumValue(string value)
         {
-            if (value == "(~0U)"
-                || value == "(~0ULL)")
+            if (value == "(~0U)")
             {
                 return "~0u";
+            }
+
+            if (value == "(~0ULL)")
+            {
+                return "~0ul";
             }
 
             if (value == "(~0U-1)")

--- a/src/Generator/CsCodeGenerator.cs
+++ b/src/Generator/CsCodeGenerator.cs
@@ -136,13 +136,13 @@ namespace Generator
                     {
                         csDataType = "float";
                     }
+                    else if (macroValue.EndsWith("UL", StringComparison.OrdinalIgnoreCase))
+                    {
+                        csDataType = "ulong";
+                    }
                     else if (macroValue.EndsWith("U", StringComparison.OrdinalIgnoreCase))
                     {
                         csDataType = "uint";
-                    }
-                    else if (macroValue.EndsWith("LL", StringComparison.OrdinalIgnoreCase))
-                    {
-                        csDataType = "ulong";
                     }
                     else if (uint.TryParse(macroValue, out _))
                     {

--- a/src/Vortice.Vulkan/Generated/Constants.cs
+++ b/src/Vortice.Vulkan/Generated/Constants.cs
@@ -33,7 +33,7 @@ namespace Vortice.Vulkan
 		/// <summary>
 		/// VK_WHOLE_SIZE = (~0ULL)
 		/// </summary>
-		public const uint WholeSize = ~0u;
+		public const ulong WholeSize = ~0ul;
 		/// <summary>
 		/// VK_ATTACHMENT_UNUSED = (~0U)
 		/// </summary>


### PR DESCRIPTION
It was resulting in default `VkBufferMemoryBarrier` ctor (using `WholeSize`) to fail with validation error:
```
[Vulkan]: Validation: ErrorEXT - Validation Error: [ VUID-VkBufferMemoryBarrier-size-01189 ] Object 0: handle = 0x1203c988, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xb63479f2 | vkCmdPipelineBarrier(): Buffer Barrier VkNonDispatchableHandle 0x42d0860000000003[] has offset 0x0 and size 0xffffffff whose sum is greater than total size 0x10. The Vulkan spec states: If size is not equal to VK_WHOLE_SIZE, size must be less than or equal to than the size of buffer minus offset (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkBufferMemoryBarrier-size-01189)
```