### PR TITLE
Improved VkString class, fixed vkMapMemory method and removed 2 dependencies for NetStandard2 build

### DIFF
--- a/src/Vortice.Vulkan/VkString.cs
+++ b/src/Vortice.Vulkan/VkString.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/Vortice.Vulkan/VkString.cs
+++ b/src/Vortice.Vulkan/VkString.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -10,38 +11,68 @@ namespace Vortice.Vulkan
 {
     public sealed class VkString : IDisposable
     {
-        private readonly GCHandle _handle;
+        private GCHandle _handle;
 
-        public VkString(string str) 
+        /// <summary>
+        /// Size of the byte array that is created from the string.
+        /// This value is bigger then the length of the string because '\0' is added at the end of the string and because some UTF8 characters can be longer then 1 byte.
+        /// When Size is 0, then this represents a null string or disposed VkString.
+        /// </summary>
+        public int Size { get; private set; }
+
+
+        public VkString(string? str) 
         {
-            var data = Encoding.UTF8.GetBytes(str);
+            if (str == null)
+                return; // Preserve Size as 0
+
+            var data = Encoding.UTF8.GetBytes(str + '\0'); // Vulkan expects '\0' terminated UTF8 string
+
             _handle = GCHandle.Alloc(data, GCHandleType.Pinned);
-            Size = data.Length;
+
+            Size = data.Length; // note that empty string will have Size set to 1 because of added '\0'
         }
 
-        ~VkString()
-        {
-            Dispose();
-        }
+        ~VkString() => this.DisposeInt();
 
         public void Dispose()
         {
-            if (_handle.IsAllocated)
-                _handle.Free();
+            DisposeInt();
+            GC.SuppressFinalize(this); // Remove from finalizer queue
         }
 
-        public unsafe byte* Pointer => (byte*)_handle.AddrOfPinnedObject().ToPointer();
-        public readonly int Size;
-
-        private unsafe string GetString()
+        private void DisposeInt()
         {
+            if (Size == 0) // Already disposed or not allocated?
+                return;
+
+            _handle.Free();
+            Size = 0; // This will also mark the VkString as disposed
+        }
+
+        public unsafe byte* Pointer
+        {
+            get
+            {
+                if (Size == 0)
+                    return (byte*)0;
+
+                return (byte*)_handle.AddrOfPinnedObject().ToPointer();
+            }
+        }
+
+        private unsafe string? GetString()
+        {
+            if (Size == 0)
+                return null;
+
             return Encoding.UTF8.GetString(Pointer, Size);
         }
 
         public static unsafe implicit operator byte*(VkString value) => value.Pointer;
         public static unsafe implicit operator IntPtr(VkString value) => new IntPtr(value.Pointer);
         public static implicit operator VkString(string str) => new VkString(str);
-        public static implicit operator string(VkString str) => str.GetString();
+        public static implicit operator string?(VkString str) => str.GetString();
     }
 
     public sealed unsafe class VkStringArray : IDisposable
@@ -77,16 +108,22 @@ namespace Vortice.Vulkan
 
         ~VkStringArray()
         {
-            Dispose();
+            DisposeInt();
         }
 
         public void Dispose()
         {
-            if (!_disposed)
-            {
-                _disposed = true;
-                Marshal.FreeHGlobal(Pointer);
-            }
+            DisposeInt();
+            GC.SuppressFinalize(this); // Remove from finalizer queue
+        }
+
+        private void DisposeInt()
+        {
+            if (_disposed)
+                return;
+
+            Marshal.FreeHGlobal(Pointer);
+            _disposed = true;
         }
 
         public VkString this[int index]

--- a/src/Vortice.Vulkan/Vortice.Vulkan.csproj
+++ b/src/Vortice.Vulkan/Vortice.Vulkan.csproj
@@ -18,8 +18,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Bcl.HashCode " Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Vortice.Vulkan/Vulkan.cs
+++ b/src/Vortice.Vulkan/Vulkan.cs
@@ -520,16 +520,14 @@ namespace Vortice.Vulkan
 
         public static void vkCmdSetBlendConstants(VkCommandBuffer commandBuffer, float red, float green, float blue, float alpha)
         {
-            float[] blendConstants = new[] { red, green, blue, alpha };
-            fixed (float* blendConstantsPtr = &blendConstants[0])
-            {
-                vkCmdSetBlendConstants(commandBuffer, blendConstantsPtr);
-            }
+            var blendConstantsArray = stackalloc float[] { red, green, blue, alpha };
+            vkCmdSetBlendConstants(commandBuffer, blendConstantsArray);
         }
 
         public static void vkCmdSetBlendConstants(VkCommandBuffer commandBuffer, Color4 blendConstants)
         {
-            vkCmdSetBlendConstants(commandBuffer, (float*)Unsafe.AsPointer(ref blendConstants));
+            var blendConstantsArray = stackalloc float[] { blendConstants.R, blendConstants.G, blendConstants.B, blendConstants.A };
+            vkCmdSetBlendConstants(commandBuffer, blendConstantsArray);
         }
 
         public static void vkCmdSetFragmentShadingRateKHR(VkCommandBuffer commandBuffer, Size* fragmentSize, VkFragmentShadingRateCombinerOpKHR[] combinerOps)

--- a/src/Vortice.Vulkan/Vulkan.cs
+++ b/src/Vortice.Vulkan/Vulkan.cs
@@ -243,10 +243,13 @@ namespace Vortice.Vulkan
             if (size == WholeSize)
             {
                 vkGetBufferMemoryRequirements(device, buffer, out VkMemoryRequirements memoryRequirements);
-                return new Span<T>(pData, (int)memoryRequirements.size);
+                size = memoryRequirements.size;
             }
 
-            return new Span<T>(pData, (int)size);
+            int oneItemSize = sizeof(T);
+            int spanLength = (int)size / oneItemSize;
+
+            return new Span<T>(pData, spanLength);
         }
 
         public static Span<T> vkMapMemory<T>(VkDevice device, VkImage image, VkDeviceMemory memory, ulong offset = 0, ulong size = WholeSize, VkMemoryMapFlags flags = VkMemoryMapFlags.None) where T : unmanaged
@@ -257,10 +260,13 @@ namespace Vortice.Vulkan
             if (size == WholeSize)
             {
                 vkGetImageMemoryRequirements(device, image, out VkMemoryRequirements memoryRequirements);
-                return new Span<T>(pData, (int)memoryRequirements.size);
+                size = memoryRequirements.size;
             }
 
-            return new Span<T>(pData, (int)size);
+            int oneItemSize = sizeof(T);
+            int spanLength = (int)size / oneItemSize;
+
+            return new Span<T>(pData, spanLength);
         }
 
         public static void vkUpdateDescriptorSets(VkDevice device, VkWriteDescriptorSet writeDescriptorSet)


### PR DESCRIPTION
Some additional comments:

VkString fix:
- Fixed getting null terminated string by adding '\0' to the string (the current code actually worked because .Net adds a few 0 bytes after each object in memory, but we should not rely on that).
- Removed readonly from _handle field. This prevented using copies of GcHandle when calling Free or AddrOfPinnedObject - see https://www.jetbrains.com/help/resharper/ImpureMethodCallOnReadonlyValueField.html
- Removing readonly from _handle also fixed disposing because before when the _handle.Free method was called, this was done on the copy of the GcHandle and therefore the IsAllocated on the original GcHandle was still true - so calling Dispose multiple times would call _handle.Free multiple times (this may throw InvalidOperationException according to documentation).
  Actually the Dispose method was updated to check if Size is 0 instead of checking IsAllocated.
- Improved disposing with providing proper dispose pattern that also calls "GC.SuppressFinalize(this)" to remove the object from the finalizer queue in case of manual disposal.
- Added support for initialization of VkString with null string.
- Removed readonly from Size so it can be set to 0 when disposed.

vkMapMemory fix:
- Fixed creating new Span<T> object - the constructor takes number of T items in the span and not size in bytes. The current code worked only when T was byte, otherwise it created too big Span and can lead to out-of-bounds writes.

Removed 2 dependencies for Net Standard 2.0 build.
- Removed Microsoft.Bcl.HashCode - it was never used
- Removed System.Runtime.CompilerServices.Unsafe - the Update method was used only once so a small code change was required to remove its usage (the code now uses stackalloc)

In my opinion, it would be better that the library would have as few dependencies as possible - I preferred the version that did not depend on the Vortice.Mathematics because this allowed us to use any math library. Also the cost of not using Vortice.Mathematics was not that bad (adding a few types like VkRect, VkViewport, VkExtent2D). Anyway, I also use Vortice.Mathematics so this is currently not a problem for me, but still I think that the value of the library is decreased by forcing you to use some other library.


Please also enable GitHub Discussions for the library - https://docs.github.com/en/discussions/quickstart
It would be great if we could reach you and discuss and provide feedback about the library. Otherwise, the development is one-way process and this is a little bit "scary" from my perspective because this library is an essential part of the application.

And finally, a message that would need to go to the Discussions section:
GREAT WORK SO FAR and thank very much you for maintaining and updating the library so regularly!!!