### PR TITLE
Add shaderc include callback support to Vortice.ShaderCompiler

### DIFF
--- a/src/Vortice.ShaderCompiler/Compiler.cs
+++ b/src/Vortice.ShaderCompiler/Compiler.cs
@@ -22,6 +22,7 @@ namespace Vortice.ShaderCompiler
         }
 
         public Options Options { get; }
+        public IIncluder? Includer;
 
         /// <summary>
         /// Finalizes an instance of the <see cref="Compiler" /> class.
@@ -41,6 +42,7 @@ namespace Vortice.ShaderCompiler
 
             if (disposing)
             {
+                Includer?.Dispose(Options);
                 Options.Dispose();
                 shaderc_compiler_release(_handle);
             }
@@ -48,6 +50,7 @@ namespace Vortice.ShaderCompiler
 
         public Result Compile(string source, string fileName, ShaderKind shaderKind, string entryPoint = "main")
         {
+            Includer?.Activate(Options);
             return new Result(shaderc_compile_into_spv(_handle, source, (nuint)source.Length, (byte)shaderKind, fileName, entryPoint, Options.Handle));
         }
 

--- a/src/Vortice.ShaderCompiler/Includer.cs
+++ b/src/Vortice.ShaderCompiler/Includer.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Amer Koleci and contributors.
+// Distributed under the MIT license. See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using static Vortice.ShaderCompiler.Native;
+
+namespace Vortice.ShaderCompiler
+{
+    public interface IIncluder
+    {
+        void Activate(Options options);
+        void Dispose(Options options);
+    }
+
+    public class Includer : IIncluder
+    {
+        public string RootPath;
+
+        private GCHandle _includerGCHandle = new();
+        private Dictionary<string, IntPtr> _shadercIncludeResults = new();
+        private Dictionary<IntPtr, string> _ptrToName = new();
+        private Dictionary<string, string> _sourceToPath = new();
+
+        public unsafe Includer(string rootPath = ".")
+        {
+            RootPath = rootPath;
+        }
+
+        public unsafe void Activate(Options options)
+        {
+            if (!_includerGCHandle.IsAllocated)
+                _includerGCHandle = GCHandle.Alloc(this);
+            shaderc_compile_options_set_include_callbacks(options.Handle, shaderc_include_resolve, shaderc_include_result_release, (void*)GCHandle.ToIntPtr(_includerGCHandle));
+        }
+
+        public unsafe void Dispose(Options options)
+        {
+#pragma warning disable CS8600, CS8625
+            shaderc_compile_options_set_include_callbacks(options.Handle, null, null, null);
+#pragma warning restore CS8600, CS8625
+            foreach (var includeResultPtr in _shadercIncludeResults.Values)
+                Free(includeResultPtr);
+            _sourceToPath = new();
+            _ptrToName = new();
+            _shadercIncludeResults = new();
+            if (_includerGCHandle.IsAllocated)
+                _includerGCHandle.Free();
+        }
+
+        private static unsafe nint shaderc_include_resolve(void* user_data, [MarshalAs(UnmanagedType.LPStr)] string requested_source, int type, [MarshalAs(UnmanagedType.LPStr)] string requesting_source, UIntPtr include_depth)
+        {
+            GCHandle gch = GCHandle.FromIntPtr((IntPtr)user_data);
+#pragma warning disable CS8600
+            Includer includer = (Includer)gch.Target;
+#pragma warning restore CS8600
+
+#pragma warning disable CS8602
+            if (!includer._shadercIncludeResults.TryGetValue(requested_source, out var includeResultPtr))
+#pragma warning restore CS8602
+            {
+                Native.shaderc_include_result includeResult = new();
+                string path = requested_source;
+                if (!Path.IsPathRooted(path))
+                {
+                    string rootPath = includer.RootPath;
+                    if (includer._sourceToPath.ContainsKey(requesting_source)) {
+                        rootPath = Path.GetDirectoryName(includer._sourceToPath[requesting_source]);
+                    }
+                    path = Path.Join(rootPath, path);
+                }
+                includeResult.content = File.ReadAllText(path);
+                includeResult.content_length = (UIntPtr)includeResult.content.Length;
+                includeResult.source_name = requested_source;
+                includeResult.source_name_length = (UIntPtr)includeResult.source_name.Length;
+
+                includeResultPtr = Marshal.AllocHGlobal(Marshal.SizeOf(includeResult));
+                Marshal.StructureToPtr(includeResult, includeResultPtr, false);
+                includer._shadercIncludeResults.Add(requested_source, includeResultPtr);
+                includer._ptrToName.Add(includeResultPtr, requested_source);
+                includer._sourceToPath.Add(requested_source, path);
+            }
+            return includeResultPtr;
+        }
+
+        private static unsafe void shaderc_include_result_release(void* user_data, nint include_result)
+        {
+            GCHandle gch = GCHandle.FromIntPtr((IntPtr)user_data);
+#pragma warning disable CS8600
+            Includer includer = (Includer)gch.Target;
+#pragma warning restore CS8600
+
+#pragma warning disable CS8602
+            if (includer._ptrToName.TryGetValue(include_result, out var path))
+#pragma warning restore CS8602
+            {
+                includer._ptrToName.Remove(include_result);
+                includer._shadercIncludeResults.Remove(path);
+                includer.Free(include_result);
+            }
+        }
+
+        private unsafe void Free(IntPtr includeResultPtr)
+        {
+            Marshal.DestroyStructure(includeResultPtr, typeof(Native.shaderc_include_result));
+            Marshal.FreeHGlobal(includeResultPtr);
+        }
+    }
+}

--- a/src/Vortice.ShaderCompiler/Native.cs
+++ b/src/Vortice.ShaderCompiler/Native.cs
@@ -81,6 +81,45 @@ namespace Vortice.ShaderCompiler
             shaderc_compile_options_set_forced_version_profile_(options, version, profile);
         }
 
+        /// <summary>An include result. https://github.com/google/shaderc/blob/c42db5815fad0424f0f1311de1eec92cdd77203d/libshaderc/include/shaderc/shaderc.h#L325</summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 0)]
+        public struct shaderc_include_result
+        {
+            /// <summary>
+            /// The name of the source file.  The name should be fully resolved
+            /// in the sense that it should be a unique name in the context of the
+            /// includer.  For example, if the includer maps source names to files in
+            /// a filesystem, then this name should be the absolute path of the file.
+            /// For a failed inclusion, this string is empty.
+            /// </summary>
+            [MarshalAs(UnmanagedType.LPStr)] public string source_name;
+            public UIntPtr source_name_length;
+            /// <summary>
+            /// The text contents of the source file in the normal case.
+            /// For a failed inclusion, this contains the error message.
+            /// </summary>
+            [MarshalAs(UnmanagedType.LPStr)] public string content;
+            public UIntPtr content_length;
+            /// <summary>
+            /// User data to be passed along with this request.
+            /// </summary>
+            public void* user_data;
+        }
+        /// <returns>shaderc_include_result</returns>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate nint PFN_shaderc_include_resolve_fn(void* user_data, [MarshalAs(UnmanagedType.LPStr)] string requested_source, int type, [MarshalAs(UnmanagedType.LPStr)] string requesting_source, UIntPtr include_depth);
+        /// <param name="user_data">User data</param>
+        /// <param name="include_result">shaderc_include_result</param>
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void PFN_shaderc_include_result_release_fn(void* user_data, nint include_result);
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate void PFN_shaderc_compile_options_set_include_callbacks(nint options, PFN_shaderc_include_resolve_fn resolver, PFN_shaderc_include_result_release_fn result_releaser, void* user_data);
+        private static readonly PFN_shaderc_compile_options_set_include_callbacks shaderc_compile_options_set_include_callbacks_ = LoadFunction<PFN_shaderc_compile_options_set_include_callbacks>("shaderc_compile_options_set_include_callbacks");
+        public static void shaderc_compile_options_set_include_callbacks(nint options, PFN_shaderc_include_resolve_fn resolver, PFN_shaderc_include_result_release_fn result_releaser, void* user_data)
+        {
+            shaderc_compile_options_set_include_callbacks_(options, resolver, result_releaser, user_data);
+        }
+
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate nint PFN_shaderc_compile_options_set_suppress_warnings(nint options);
         private static readonly PFN_shaderc_compile_options_set_suppress_warnings shaderc_compile_options_set_suppress_warnings_ = LoadFunction<PFN_shaderc_compile_options_set_suppress_warnings>("shaderc_compile_options_set_suppress_warnings");

--- a/src/Vortice.ShaderCompiler/Vortice.ShaderCompiler.csproj
+++ b/src/Vortice.ShaderCompiler/Vortice.ShaderCompiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>https://github.com/google/shaderc bindings.</Description>
     <PackageTags>3D graphics vulkan standard game gamedev</PackageTags>
   </PropertyGroup>

--- a/src/tests/Vortice.ShaderCompiler.Test/Assets/Includes/A.glsl
+++ b/src/tests/Vortice.ShaderCompiler.Test/Assets/Includes/A.glsl
@@ -1,0 +1,1 @@
+#include "B.glsl"

--- a/src/tests/Vortice.ShaderCompiler.Test/Assets/Includes/B.glsl
+++ b/src/tests/Vortice.ShaderCompiler.Test/Assets/Includes/B.glsl
@@ -1,0 +1,1 @@
+#define INCLUDED_MACRO(x) x

--- a/src/tests/Vortice.ShaderCompiler.Test/Assets/TriangleVertex.glsl
+++ b/src/tests/Vortice.ShaderCompiler.Test/Assets/TriangleVertex.glsl
@@ -4,8 +4,10 @@ layout(location = 0) in vec4 in_var_POSITION;
 layout(location = 1) in vec4 in_var_COLOR;
 layout(location = 0) out vec4 out_var_COLOR;
 
+#include "Includes/A.glsl"
+
 void main()
 {
     gl_Position = in_var_POSITION;
-    out_var_COLOR = in_var_COLOR;
+    out_var_COLOR = INCLUDED_MACRO(in_var_COLOR);
 }

--- a/src/tests/Vortice.ShaderCompiler.Test/CompileTests.cs
+++ b/src/tests/Vortice.ShaderCompiler.Test/CompileTests.cs
@@ -20,6 +20,7 @@ namespace Vortice.Dxc.Test
 
             using (var compiler = new Compiler())
             {
+                compiler.Includer = new Includer(Path.GetDirectoryName(shaderSourceFile)!);
                 using (var result = compiler.Compile(shaderSource, shaderSourceFile, ShaderKind.VertexShader))
                 {
                     Assert.Equal(CompilationStatus.Success, result.Status);

--- a/src/tests/Vortice.ShaderCompiler.Test/Vortice.ShaderCompiler.Test.csproj
+++ b/src/tests/Vortice.ShaderCompiler.Test/Vortice.ShaderCompiler.Test.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Vortice.ShaderCompiler\Vortice.ShaderCompiler.csproj" />
+    <ProjectReference Include="..\..\Vortice.ShaderCompiler\Vortice.ShaderCompiler.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Assets\*">
+    <Content Include="Assets\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
This adds optional [shaderc_compile_options_set_include_callbacks](https://github.com/google/shaderc/blob/c42db5815fad0424f0f1311de1eec92cdd77203d/libshaderc/include/shaderc/shaderc.h#L365) support to `Vortice.ShaderCompiler`, so that one can use GLSL `#include` statements. There is a new `IIncluder` interface used in `Compiler`, and an `Includer` default implementation.

I've extended the test and use this in a private project, it works well so far. But I removed `netstandard2.0` from `Vortice.ShaderCompiler.csproj` due to use of `Path.Join`, so this PR probably shouldn't be merged without modifications.