### PR TITLE
Fix Linux library load name for SpirvCross

### DIFF
--- a/src/Vortice.SpirvCross/SpirvCrossApi.cs
+++ b/src/Vortice.SpirvCross/SpirvCrossApi.cs
@@ -76,7 +76,7 @@ internal static unsafe class SpirvCrossApi
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            return LibraryLoader.LoadLocalLibrary("libshaderc_shared.so");
+            return LibraryLoader.LoadLocalLibrary("libspirv-cross-c-shared.so");
         }
         else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {


### PR DESCRIPTION
SpirvCross project had it's Linux library name set to `libshaderc_shared.so`, but it should be `libspirv-cross-c-shared.so`.
PR changes it to be the correct name.